### PR TITLE
Start setting up Newt and Tag API

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -2,6 +2,8 @@ const router = require('express').Router();
 
 module.exports = router;
 
+router.use('/newts', require('./newts'));
+router.use('/tags', require('./tags'));
 router.use('/users', require('./users'));
 
 router.use((req, res, next) => {

--- a/server/api/newts.js
+++ b/server/api/newts.js
@@ -1,0 +1,213 @@
+const router = require('express').Router();
+
+const {
+  Newt,
+  Tag,
+} = require('../db/models');
+
+module.exports = router;
+
+// GET    /api/newts                          // returns all newt objects
+// POST   /api/newts/addnewt                  // creates a new newt
+// GET    /api/newts/:newtId                  // returns one newt object
+// PUT    /api/newts/:newtId                  // updates a newt
+// DELETE /api/newts/:newtId                  // deletes a newt
+
+// GET /api/newts - returns all newt objects
+router.get('/', (req, res, next) => Newt.findAll({
+  include: [{
+    model: Tag,
+    as: 'Tagges',
+  }],
+})
+  .then(foundNewts => res.json(foundNewts))
+  .catch(next));
+
+// POST /api/newts/addnewt
+router.post('/addnewt', (req, res, next) => Newt.create(req.body)
+    .then(newnewt => res.status(201).json(newnewt))
+    .catch(next));
+
+// // GET /api/newts/:newtId
+// // PUT /api/newts/:newtId
+// // DELETE /api/newts/:newtId
+// router.route('/:newtId')
+// // Using findOne instead of findAll for GET, to avoid storing the whole newt text unnecessarily
+//   .get((req, res, next) => Newt.findOne({
+//     attributes: ['id', 'title', 'year', 'wordCount', 'uniqueCount', 'coverURL', 'pgURL', 'wikipediaURL', 'sentenceArray', 'wordMap'],
+//     where: { id: req.params.newtId },
+//     include: [{
+//       model: Author,
+//       as: 'Creators',
+//       attributes: ['firstName', 'lastName'],
+//     }],
+//   })
+//     .then(newt => res.json(newt))
+//     .catch(next))
+//   .put((req, res, next) => Newt.findById(req.params.newtId)
+//     .then(newt => newt.update(req.body, {
+//       returning: true,
+//       plain: true,
+//     }))
+//     .then(updated => res.send({ message: 'Updated sucessfully', updated }))
+//     .catch(next))
+//   .delete((req, res, next) => Newt.findById(req.params.newtId)
+//     .then(foundNewt => foundNewt.destroy())
+//     .then(() => res.send({ message: 'Deleted successfully' }))
+//     .catch(next));
+
+// // ----------------------- BOOK-SENTENCE ROUTES --------------------------------
+
+// // GET    /api/newts/:newtId/sentences        // returns all of a newt’s sentences
+// // POST   /api/newts/:newtId/sentences        // stores all of a newt’s sentences
+// // GET    /api/newts/:newtId/sentences/:word  // returns all of a newt’s sentences
+// //                                               that contain a given word
+
+// // Either GET or POST on /api/newts/:newtId/sentences will create a sentenceArray
+// // if one doesn't yet exist. The difference is whether you get a saucy response.
+
+// // GET /api/newts/:newtId/sentences
+// //   Returns all of a newt’s sentences
+// // POST /api/newts/:newtId/sentences
+// //   Stores all of a newt’s sentences - should happen during the import process—
+// //   probably as an afterCreate hook.
+// router.route('/:newtId/sentences')
+//   // 1. get the newt’s text
+//   .get((req, res, next) => Newt.findById(req.params.newtId)
+//   // 2. tokenize the text
+//     .then((foundNewt) => {
+//       let sentenceArray;
+//       if (foundNewt.sentencesTokenized) {
+//         sentenceArray = foundNewt.sentenceArray; // I'm a teapot
+//       } else {
+//         sentenceArray = sentenceTokenizer.tokenize(foundNewt.text);
+//         foundNewt.update({
+//           sentenceArray,
+//           sentencesTokenized: true,
+//         }, {
+//           returning: true,
+//           plain: true,
+//         });
+//       }
+//       return sentenceArray;
+//     // 3. build an array of objects
+//     })
+//     .then(allSentences => res.json(allSentences))
+//     .catch(next))
+//   // 1. get the newt’s text
+//   .post((req, res, next) => Newt.findById(req.params.newtId)
+//   // 2. tokenize the text
+//     .then((foundNewt) => {
+//       let sentenceArray;
+//       let status;
+//       if (foundNewt.sentencesTokenized) {
+//         sentenceArray = foundNewt.sentenceArray;
+//         status = 218; // I'm a teapot
+//       } else {
+//         status = 201;
+//         sentenceArray = sentenceTokenizer.tokenize(foundNewt.text);
+//         foundNewt.update({
+//           sentenceArray,
+//           sentencesTokenized: true,
+//         }, {
+//           returning: true,
+//           plain: true,
+//         });
+//       }
+//       return { sentenceArray, status };
+//     })
+//     .then(({ sentenceArray, status }) => res.status(status).json(sentenceArray))
+//     .catch(next));
+
+// // GET /api/newts/:newtId/sentences/:word
+// // Returns all of a newt’s sentences that contain a given word
+// router.get('/:newtId/sentences/:word', (req, res, next) => {
+//   // Sentence.findAll({
+//   //   where: {
+//   //     newtId: req.params.newtId
+//   //   }
+//   // })
+//   Newt.findById(req.params.newtId).sentenceArray
+//     .then(newtSentences => newtSentences.filter(sentence => sentence.indexOf(req.params.word) > -1))
+//     .then(wordSentences => res.json(wordSentences))
+//     .catch(next);
+// });
+
+// // ------------------------ BOOK-WORD ROUTES -----------------------------------
+
+// // GET    /api/newts/:newtId/words            // returns all words in a newt
+// // POST   /api/newts/:newtId/words            // stores all of a newt’s words
+
+// // Either GET or POST on /api/newts/:newtId/words will create a wordMap object
+// // if one doesn't yet exist. The difference is whether you get a saucy response.
+
+// function mapWords(arr) {
+//   const map = {};
+//   arr.forEach((word) => {
+//     if (!Number(word)) {
+//       map[word] = map[word] + 1 || 1;
+//     }
+//   });
+//   return JSON.stringify(map);
+// }
+
+// // GET /api/newts/:newtId/words
+// //   Returns a list of all words in a newt.
+// //   If the newt has already been tokenized, retrieve the existing list.
+// //   Otherwise, condense the array into an object, post it to the newt’s `wordMap`
+// //   field, and then return the wordMap.
+// // POST /api/newts/:newtId/words
+// //   Stores all of a newt’s words
+// //   If the newt has already been tokenized, say you’re a teapot.
+// //   Otherwise, post the array to the newt’s `wordArray` field.
+//   // 1. Get the newt object
+// router.route('/:newtId/words')
+//   .get((req, res, next) => Newt.findById(req.params.newtId)
+//     .then((foundNewt) => {
+//       let wordMap;
+//       // 2. Check whether it's already been tokenized
+//       if (foundNewt.wordsTokenized) {
+//         wordMap = foundNewt.wordMap;
+//       } else {
+//       // 3. Tokenize the text
+//         const wordArray = wordTokenizer.tokenize(foundNewt.text);
+//         wordMap = mapWords(wordArray);
+//         foundNewt.update({
+//           wordMap,
+//           wordsTokenized: true,
+//           wordCount: wordArray.length,
+//           uniqueCount: Object.keys(wordMap).length,
+//         }, {
+//           returning: true,
+//           plain: true,
+//         });
+//       }
+//       return wordMap;
+//     })
+//     .then(allWords => res.send(allWords))
+//     .catch(next))
+//   // 1. Get the newt object
+//   .post((req, res, next) => Newt.findById(req.params.newtId)
+//     .then((foundNewt) => {
+//       let wordMap;
+//       let status;
+//       // 2. Check whether it's already been tokenized
+//       if (foundNewt.wordsTokenized) {
+//         wordMap = foundNewt.wordMap;
+//         status = 218;
+//       } else {
+//         status = 201;
+//         // 3. Tokenize the text
+//         const wordArray = wordTokenizer.tokenize(foundNewt.text);
+//         wordMap = mapWords(wordArray);
+//         foundNewt.update({
+//           wordMap,
+//           wordsTokenized: true,
+//           wordCount: wordArray.length,
+//           uniqueCount: Object.keys(wordMap).length,
+//         });
+//       }
+//       return { wordMap, status };
+//     })
+//     .then(({ wordMap, status }) => res.status(status).send(wordMap))
+//     .catch(next));

--- a/server/api/newts.js
+++ b/server/api/newts.js
@@ -7,11 +7,13 @@ const {
 
 module.exports = router;
 
-// GET    /api/newts                          // returns all newt objects
-// POST   /api/newts/addnewt                  // creates a new newt
-// GET    /api/newts/:newtId                  // returns one newt object
-// PUT    /api/newts/:newtId                  // updates a newt
-// DELETE /api/newts/:newtId                  // deletes a newt
+// ----------------------------- API Summary -----------------------------------
+// GET     /api/newts          // returns all newt objects
+// POST    /api/newts/addnewt  // creates a new newt
+// GET     /api/newts/:newtId  // returns one newt object
+// PUT     /api/newts/:newtId  // updates a newt
+// DELETE  /api/newts/:newtId  // deletes a newt
+// -----------------------------------------------------------------------------
 
 // GET /api/newts - returns all newt objects
 router.get('/', (req, res, next) => Newt.findAll({
@@ -25,189 +27,30 @@ router.get('/', (req, res, next) => Newt.findAll({
 
 // POST /api/newts/addnewt
 router.post('/addnewt', (req, res, next) => Newt.create(req.body)
-    .then(newnewt => res.status(201).json(newnewt))
+  .then(newNewt => res.status(201).json(newNewt))
+  .catch(next));
+
+// GET /api/newts/:newtId
+// PUT /api/newts/:newtId
+// DELETE /api/newts/:newtId
+router.route('/:newtId')
+  .get((req, res, next) => Newt.findOne({
+    where: { id: req.params.newtId },
+    include: [{
+      model: Tag,
+      as: 'Tagges',
+    }],
+  })
+    .then(foundNewt => res.json(foundNewt))
+    .catch(next))
+  .put((req, res, next) => Newt.findById(req.params.newtId)
+    .then(foundNewt => foundNewt.update(req.body, {
+      returning: true,
+      plain: true,
+    }))
+    .then(updated => res.send({ message: 'Updated sucessfully', updated }))
+    .catch(next))
+  .delete((req, res, next) => Newt.findById(req.params.newtId)
+    .then(foundNewt => foundNewt.destroy())
+    .then(() => res.send({ message: 'Deleted successfully' }))
     .catch(next));
-
-// // GET /api/newts/:newtId
-// // PUT /api/newts/:newtId
-// // DELETE /api/newts/:newtId
-// router.route('/:newtId')
-// // Using findOne instead of findAll for GET, to avoid storing the whole newt text unnecessarily
-//   .get((req, res, next) => Newt.findOne({
-//     attributes: ['id', 'title', 'year', 'wordCount', 'uniqueCount', 'coverURL', 'pgURL', 'wikipediaURL', 'sentenceArray', 'wordMap'],
-//     where: { id: req.params.newtId },
-//     include: [{
-//       model: Author,
-//       as: 'Creators',
-//       attributes: ['firstName', 'lastName'],
-//     }],
-//   })
-//     .then(newt => res.json(newt))
-//     .catch(next))
-//   .put((req, res, next) => Newt.findById(req.params.newtId)
-//     .then(newt => newt.update(req.body, {
-//       returning: true,
-//       plain: true,
-//     }))
-//     .then(updated => res.send({ message: 'Updated sucessfully', updated }))
-//     .catch(next))
-//   .delete((req, res, next) => Newt.findById(req.params.newtId)
-//     .then(foundNewt => foundNewt.destroy())
-//     .then(() => res.send({ message: 'Deleted successfully' }))
-//     .catch(next));
-
-// // ----------------------- BOOK-SENTENCE ROUTES --------------------------------
-
-// // GET    /api/newts/:newtId/sentences        // returns all of a newt’s sentences
-// // POST   /api/newts/:newtId/sentences        // stores all of a newt’s sentences
-// // GET    /api/newts/:newtId/sentences/:word  // returns all of a newt’s sentences
-// //                                               that contain a given word
-
-// // Either GET or POST on /api/newts/:newtId/sentences will create a sentenceArray
-// // if one doesn't yet exist. The difference is whether you get a saucy response.
-
-// // GET /api/newts/:newtId/sentences
-// //   Returns all of a newt’s sentences
-// // POST /api/newts/:newtId/sentences
-// //   Stores all of a newt’s sentences - should happen during the import process—
-// //   probably as an afterCreate hook.
-// router.route('/:newtId/sentences')
-//   // 1. get the newt’s text
-//   .get((req, res, next) => Newt.findById(req.params.newtId)
-//   // 2. tokenize the text
-//     .then((foundNewt) => {
-//       let sentenceArray;
-//       if (foundNewt.sentencesTokenized) {
-//         sentenceArray = foundNewt.sentenceArray; // I'm a teapot
-//       } else {
-//         sentenceArray = sentenceTokenizer.tokenize(foundNewt.text);
-//         foundNewt.update({
-//           sentenceArray,
-//           sentencesTokenized: true,
-//         }, {
-//           returning: true,
-//           plain: true,
-//         });
-//       }
-//       return sentenceArray;
-//     // 3. build an array of objects
-//     })
-//     .then(allSentences => res.json(allSentences))
-//     .catch(next))
-//   // 1. get the newt’s text
-//   .post((req, res, next) => Newt.findById(req.params.newtId)
-//   // 2. tokenize the text
-//     .then((foundNewt) => {
-//       let sentenceArray;
-//       let status;
-//       if (foundNewt.sentencesTokenized) {
-//         sentenceArray = foundNewt.sentenceArray;
-//         status = 218; // I'm a teapot
-//       } else {
-//         status = 201;
-//         sentenceArray = sentenceTokenizer.tokenize(foundNewt.text);
-//         foundNewt.update({
-//           sentenceArray,
-//           sentencesTokenized: true,
-//         }, {
-//           returning: true,
-//           plain: true,
-//         });
-//       }
-//       return { sentenceArray, status };
-//     })
-//     .then(({ sentenceArray, status }) => res.status(status).json(sentenceArray))
-//     .catch(next));
-
-// // GET /api/newts/:newtId/sentences/:word
-// // Returns all of a newt’s sentences that contain a given word
-// router.get('/:newtId/sentences/:word', (req, res, next) => {
-//   // Sentence.findAll({
-//   //   where: {
-//   //     newtId: req.params.newtId
-//   //   }
-//   // })
-//   Newt.findById(req.params.newtId).sentenceArray
-//     .then(newtSentences => newtSentences.filter(sentence => sentence.indexOf(req.params.word) > -1))
-//     .then(wordSentences => res.json(wordSentences))
-//     .catch(next);
-// });
-
-// // ------------------------ BOOK-WORD ROUTES -----------------------------------
-
-// // GET    /api/newts/:newtId/words            // returns all words in a newt
-// // POST   /api/newts/:newtId/words            // stores all of a newt’s words
-
-// // Either GET or POST on /api/newts/:newtId/words will create a wordMap object
-// // if one doesn't yet exist. The difference is whether you get a saucy response.
-
-// function mapWords(arr) {
-//   const map = {};
-//   arr.forEach((word) => {
-//     if (!Number(word)) {
-//       map[word] = map[word] + 1 || 1;
-//     }
-//   });
-//   return JSON.stringify(map);
-// }
-
-// // GET /api/newts/:newtId/words
-// //   Returns a list of all words in a newt.
-// //   If the newt has already been tokenized, retrieve the existing list.
-// //   Otherwise, condense the array into an object, post it to the newt’s `wordMap`
-// //   field, and then return the wordMap.
-// // POST /api/newts/:newtId/words
-// //   Stores all of a newt’s words
-// //   If the newt has already been tokenized, say you’re a teapot.
-// //   Otherwise, post the array to the newt’s `wordArray` field.
-//   // 1. Get the newt object
-// router.route('/:newtId/words')
-//   .get((req, res, next) => Newt.findById(req.params.newtId)
-//     .then((foundNewt) => {
-//       let wordMap;
-//       // 2. Check whether it's already been tokenized
-//       if (foundNewt.wordsTokenized) {
-//         wordMap = foundNewt.wordMap;
-//       } else {
-//       // 3. Tokenize the text
-//         const wordArray = wordTokenizer.tokenize(foundNewt.text);
-//         wordMap = mapWords(wordArray);
-//         foundNewt.update({
-//           wordMap,
-//           wordsTokenized: true,
-//           wordCount: wordArray.length,
-//           uniqueCount: Object.keys(wordMap).length,
-//         }, {
-//           returning: true,
-//           plain: true,
-//         });
-//       }
-//       return wordMap;
-//     })
-//     .then(allWords => res.send(allWords))
-//     .catch(next))
-//   // 1. Get the newt object
-//   .post((req, res, next) => Newt.findById(req.params.newtId)
-//     .then((foundNewt) => {
-//       let wordMap;
-//       let status;
-//       // 2. Check whether it's already been tokenized
-//       if (foundNewt.wordsTokenized) {
-//         wordMap = foundNewt.wordMap;
-//         status = 218;
-//       } else {
-//         status = 201;
-//         // 3. Tokenize the text
-//         const wordArray = wordTokenizer.tokenize(foundNewt.text);
-//         wordMap = mapWords(wordArray);
-//         foundNewt.update({
-//           wordMap,
-//           wordsTokenized: true,
-//           wordCount: wordArray.length,
-//           uniqueCount: Object.keys(wordMap).length,
-//         });
-//       }
-//       return { wordMap, status };
-//     })
-//     .then(({ wordMap, status }) => res.status(status).send(wordMap))
-//     .catch(next));

--- a/server/api/newts.js
+++ b/server/api/newts.js
@@ -9,26 +9,26 @@ module.exports = router;
 
 // ----------------------------- API Summary -----------------------------------
 // GET     /api/newts          // returns all newt objects
-// POST    /api/newts/addnewt  // creates a new newt
+// POST    /api/newts          // creates a new newt
 // GET     /api/newts/:newtId  // returns one newt object
 // PUT     /api/newts/:newtId  // updates a newt
 // DELETE  /api/newts/:newtId  // deletes a newt
 // -----------------------------------------------------------------------------
 
 // GET /api/newts - returns all newt objects
-router.get('/', (req, res, next) => Newt.findAll({
-  include: [{
-    model: Tag,
-    as: 'Tagges',
-  }],
-})
-  .then(foundNewts => res.json(foundNewts))
-  .catch(next));
-
-// POST /api/newts/addnewt
-router.post('/addnewt', (req, res, next) => Newt.create(req.body)
-  .then(newNewt => res.status(201).json(newNewt))
-  .catch(next));
+// POST /api/newts - creates a new newt
+router.route('/')
+  .get((req, res, next) => Newt.findAll({
+    include: [{
+      model: Tag,
+      as: 'Tagges',
+    }],
+  })
+    .then(foundNewts => res.json(foundNewts))
+    .catch(next))
+  .post((req, res, next) => Newt.create(req.body)
+    .then(newNewt => res.status(201).json(newNewt))
+    .catch(next));
 
 // GET /api/newts/:newtId
 // PUT /api/newts/:newtId

--- a/server/api/tags.js
+++ b/server/api/tags.js
@@ -25,8 +25,8 @@ module.exports = router;
 //                                     corresponding newts are eagerly loaded
 // GET    /api/tags/user/:tagName   // returns all newts having the specified
 //                                     tag that are owned by the logged-in user
-// POST   /api/tags/add             // creates a new tag
-// PUT    /api/tags/update/:tagName // DOES NOT LITERALLY UPDATE A TAG RECORD.
+// POST   /api/tags/                // creates a new tag
+// PUT    /api/tags/:tagName        // DOES NOT LITERALLY UPDATE A TAG RECORD.
 //                                     let oldTagName = :tagName from the route
 //                                     let newTagName = the tagName supplied in
 //                                       the request body
@@ -38,7 +38,7 @@ module.exports = router;
 //                                     3. If `oldTagName` is orphaned by step 2
 //                                        (i.e., no newts by any user have that
 //                                        tag anymore), `oldTagName` is deleted.
-// DELETE /api/tags/delete/:tagName // DOES NOT NECESSARILY DELETE A TAG RECORD.
+// DELETE /api/tags/:tagName          // DOES NOT NECESSARILY DELETE A TAG RECORD.
 //                                     1. :tagName is removed from all newts
 //                                        owned by the logged-in user.
 //                                     2. If :tagName is orphaned by step 1
@@ -51,20 +51,47 @@ module.exports = router;
 //                        are shared with the user); if not logged in, only tags
 //                        used on public newts are shown; corresponding newts
 //                        are eagerly loaded
-router.get('/all', (req, res, next) => Tag.findAll({
-  include: [{
-    model: Newt,
-    as: 'Newttes',
-    where: {
-      [Op.or]: [
-        { public: true },
-        // { userId: req.user.id },
-      ],
-    },
-  }],
-})
-  .then(foundTags => res.json(foundTags))
-  .catch(next));
+// NOTE: This code doesn't yet identify the logged-in user.
+router.get('/all', (req, res, next) => {
+  return Tag.findAll({
+    include: [{
+      model: Newt,
+      as: 'Newttes',
+      where: {
+        [Op.or]: [
+          { public: true },
+          // { userId: req.headers.user.id },
+        ],
+      },
+    }],
+  })
+    .then(foundTags => res.json(foundTags))
+    .catch(next);
+});
+
+// GET  /api/tags/all/:tagName  // returns all newts having the specified tag
+//                                 that are accessible to the logged-in user
+//                                 (are public, belong to the user, or are
+//                                 shared with the user); if not logged in,
+//                                 only public newts are shown
+// NOTE: This code doesn't yet identify the logged-in user.
+router.get('/all/:tagName', (req, res, next) => {
+  return Tag.findAll({
+    where: { name: req.params.tagName },
+    include: [{
+      model: Newt,
+      as: 'Newttes',
+      where: {
+        [Op.or]: [
+          { public: true },
+          // { userId: req.headers.user.id },
+        ],
+      },
+    }],
+  })
+    .then(foundTags => res.json(foundTags))
+    .catch(next);
+});
 
 // GET  /api/tags/user  // returns all tags used on newts that are owned by the
 //                         logged-in user; corresponding newts are eagerly
@@ -79,32 +106,58 @@ router.get('/user', (req, res, next) => Tag.findAll({
   .then(foundTags => res.json(foundTags))
   .catch(next));
 
-// POST   /api/tags/add             // creates a new tag
-router.post('/add', (req, res, next) => Tag.create(req.body)
+// GET  /api/tags/user/:tagName  // returns all newts having the specified tag
+//                                  that are owned by the logged-in user
+router.get('/user/:tagName', (req, res, next) => {
+  return Tag.findAll({
+    where: { name: req.params.tagName },
+    include: [{
+      model: Newt,
+      as: 'Newttes',
+      where: { userId: req.user.id },
+    }],
+  })
+    .then(foundTags => res.json(foundTags))
+    .catch(next);
+});
+
+// POST  /api/tags/  // creates a new tag
+router.post('/', (req, res, next) => Tag.create(req.body)
   .then(newTag => res.status(201).json(newTag))
   .catch(next));
 
-// // GET /api/tags/:tagId
-// // PUT /api/tags/:tagId
-// // DELETE /api/tags/:tagId
-// router.route('/:tagId')
-//   .get((req, res, next) => Tag.findOne({
-//     where: { id: req.params.tagId },
-//     include: [{
-//       model: Newt,
-//       as: 'Newttes',
-//     }],
-//   })
-//     .then(foundTag => res.json(foundTag))
-//     .catch(next))
-//   .put((req, res, next) => Tag.findById(req.params.tagId)
-//     .then(foundTag => foundTag.update(req.body, {
-//       returning: true,
-//       plain: true,
-//     }))
-//     .then(updated => res.send({ message: 'Updated sucessfully', updated }))
-//     .catch(next))
-//   .delete((req, res, next) => Tag.findById(req.params.tagId)
-//     .then(foundTag => foundTag.destroy())
-//     .then(() => res.send({ message: 'Deleted successfully' }))
-//     .catch(next));
+// PUT  /api/tags/:tagName  // DOES NOT LITERALLY UPDATE A TAG RECORD.
+//                             let oldTagName = :tagName from the route
+//                             let newTagName = the tagName supplied in the
+//                               request body
+//                             1. If `newTagName` does not yet have a table row,
+//                                a new row for it is added.
+//                             2. All newts owned by the logged-in user that
+//                                have the tag `oldTagName` get `newTagName`
+//                                instead.
+//                             3. If `oldTagName` is orphaned by step 2 (i.e.,
+//                                no newts by any user have that tag anymore),
+//                                `oldTagName` is deleted.
+// DELETE  /api/tags/:tagName  // DOES NOT NECESSARILY DELETE A TAG RECORD.
+//                                1. :tagName is removed from all newts owned by
+//                                   the logged-in user.
+//                                2. If :tagName is orphaned by step 1 (i.e., no
+//                                   newts by any user have that tag anymore),
+//                                   :tagName is deleted.
+// For now, though, `put` and `delete` just work as usual.
+router.route('/:tagName')
+  .put((req, res, next) => Tag.findOne({
+    where: { name: req.params.tagName },
+  })
+    .then(foundTag => foundTag.update(req.body, {
+      returning: true,
+      plain: true,
+    }))
+    .then(updated => res.send({ message: 'Updated sucessfully', updated }))
+    .catch(next))
+  .delete((req, res, next) => Tag.findOne({
+    where: { name: req.params.tagName },
+  })
+    .then(foundTag => foundTag.destroy())
+    .then(() => res.send({ message: 'Deleted successfully' }))
+    .catch(next));

--- a/server/api/tags.js
+++ b/server/api/tags.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+
+const {
+  Newt,
+  Tag,
+} = require('../db/models');
+
+module.exports = router;

--- a/server/api/tags.js
+++ b/server/api/tags.js
@@ -1,4 +1,5 @@
 const router = require('express').Router();
+const { Op } = require('sequelize');
 
 const {
   Newt,
@@ -6,3 +7,104 @@ const {
 } = require('../db/models');
 
 module.exports = router;
+
+// ----------------------------- API Summary -----------------------------------
+// GET    /api/tags/all             // returns all tags used on newts that are
+//                                     accessible to the logged-in user (are
+//                                     public, belong to the user, or are shared
+//                                     with the user); if not logged in, only
+//                                     tags used on public newts are shown;
+//                                     corresponding newts are eagerly loaded
+// GET    /api/tags/all/:tagName    // returns all newts having the specified
+//                                     tag that are accessible to the logged-in
+//                                     user (are public, belong to the user, or
+//                                     are shared with the user); if not logged
+//                                     in, only public newts are shown
+// GET    /api/tags/user            // returns all tags used on newts that are
+//                                     owned by the logged-in user;
+//                                     corresponding newts are eagerly loaded
+// GET    /api/tags/user/:tagName   // returns all newts having the specified
+//                                     tag that are owned by the logged-in user
+// POST   /api/tags/add             // creates a new tag
+// PUT    /api/tags/update/:tagName // DOES NOT LITERALLY UPDATE A TAG RECORD.
+//                                     let oldTagName = :tagName from the route
+//                                     let newTagName = the tagName supplied in
+//                                       the request body
+//                                     1. If `newTagName` does not yet have a
+//                                        table row, a new row for it is added.
+//                                     2. All newts owned by the logged-in user
+//                                        that have the tag `oldTagName` get
+//                                        `newTagName` instead.
+//                                     3. If `oldTagName` is orphaned by step 2
+//                                        (i.e., no newts by any user have that
+//                                        tag anymore), `oldTagName` is deleted.
+// DELETE /api/tags/delete/:tagName // DOES NOT NECESSARILY DELETE A TAG RECORD.
+//                                     1. :tagName is removed from all newts
+//                                        owned by the logged-in user.
+//                                     2. If :tagName is orphaned by step 1
+//                                        (i.e., no newts by any user have that
+//                                        tag anymore), :tagName is deleted.
+// -----------------------------------------------------------------------------
+
+// GET  /api/tags/all  // returns all tags used on newts that are accessible to
+//                        the logged-in user (are public, belong to the user, or
+//                        are shared with the user); if not logged in, only tags
+//                        used on public newts are shown; corresponding newts
+//                        are eagerly loaded
+router.get('/all', (req, res, next) => Tag.findAll({
+  include: [{
+    model: Newt,
+    as: 'Newttes',
+    where: {
+      [Op.or]: [
+        { public: true },
+        // { userId: req.user.id },
+      ],
+    },
+  }],
+})
+  .then(foundTags => res.json(foundTags))
+  .catch(next));
+
+// GET  /api/tags/user  // returns all tags used on newts that are owned by the
+//                         logged-in user; corresponding newts are eagerly
+//                         loaded
+router.get('/user', (req, res, next) => Tag.findAll({
+  include: [{
+    model: Newt,
+    as: 'Newttes',
+    where: { userId: req.user.id },
+  }],
+})
+  .then(foundTags => res.json(foundTags))
+  .catch(next));
+
+// POST   /api/tags/add             // creates a new tag
+router.post('/add', (req, res, next) => Tag.create(req.body)
+  .then(newTag => res.status(201).json(newTag))
+  .catch(next));
+
+// // GET /api/tags/:tagId
+// // PUT /api/tags/:tagId
+// // DELETE /api/tags/:tagId
+// router.route('/:tagId')
+//   .get((req, res, next) => Tag.findOne({
+//     where: { id: req.params.tagId },
+//     include: [{
+//       model: Newt,
+//       as: 'Newttes',
+//     }],
+//   })
+//     .then(foundTag => res.json(foundTag))
+//     .catch(next))
+//   .put((req, res, next) => Tag.findById(req.params.tagId)
+//     .then(foundTag => foundTag.update(req.body, {
+//       returning: true,
+//       plain: true,
+//     }))
+//     .then(updated => res.send({ message: 'Updated sucessfully', updated }))
+//     .catch(next))
+//   .delete((req, res, next) => Tag.findById(req.params.tagId)
+//     .then(foundTag => foundTag.destroy())
+//     .then(() => res.send({ message: 'Deleted successfully' }))
+//     .catch(next));

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -2,14 +2,26 @@ const Newt = require('./newt');
 const Tag = require('./tag');
 const User = require('./user');
 
-Newt.belongsTo(User);
-Newt.belongsToMany(Tag, { through: 'newt_tag' });
-Newt.belongsToMany(Tag, { through: 'newt_tag' });
+// A many-to-many association such as
+//   Model1.belongsToMany(Model2, {through: 'Model2Model1'});
+//   Model2.belongsToMany(Model1, {through: 'Model2Model1'});
+// creates the following association methods:
+//   Model1.getModel2s, Model1.setModel2s, Model1.addModel2, Model1.addModel2s
+//   Model2.getModel1s, Model2.setModel1s, Model2.addModel1, Model2.addModel1s.
 
-/* We'll export all of our models here, so that any time a module needs a model,
- * we can just require it from 'db/models'.
- * For example, we can say: `const { User } = require('../db/models')`
- * instead of: `const User = require('../db/models/user')`
+Newt.belongsTo(User);
+
+Newt.belongsToMany(Tag, { as: 'Tagges', through: 'newt_tag', foreignKey: 'newtteId' });
+Tag.belongsToMany(Newt, { as: 'Newttes', through: 'newt_tag', foreignKey: 'taggeId' });
+// These associations create the following methods:
+// Newt.getTagges, Newt.setTagges, Newt.addTagge, Newt.addTagges
+// Tag.getNewttes, Tag.setNewttes, Tag.addNewtte, Tag.addNewttes
+
+/* Export all models here, so that any time a module needs a model, we can
+ * require it from 'db/models'. For example, we can say:
+ *   `const { User } = require('../db/models')`
+ * instead of
+ *   `const User = require('../db/models/user')`
  */
 module.exports = {
   Newt,

--- a/server/db/models/newt.js
+++ b/server/db/models/newt.js
@@ -43,6 +43,10 @@ const Newt = db.define('newt', {
   highlights: {
     type: TEXT,
   },
+  public: {
+    type: BOOLEAN,
+    defaultValue: false,
+  },
 });
 
 module.exports = Newt;

--- a/server/index.js
+++ b/server/index.js
@@ -93,6 +93,7 @@ const startListening = () => {
 };
 
 const syncDb = () => db.sync();
+// const syncDb = () => db.sync({ force: true });
 
 // This evaluates as true when this file is run directly from the command line,
 // i.e. when we say 'node server/index.js' (or 'nodemon server/index.js', or


### PR DESCRIPTION
Closes #9.

These API routes allow for most basic operations that are necessary to, say, seed the database. They're not safe for a multi-user situation, though.

To do: create new issue(s) to make the routes account for the logged-in user and change/delete tags responsibly.